### PR TITLE
Preserve struct-order of keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+vendor
+.idea

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/singlemusic/go-prettyjson
+
+go 1.12
+
+require (
+	github.com/davecgh/go-spew v1.1.1
+	github.com/fatih/color v1.9.0
+	gitlab.com/c0b/go-ordered-json v0.0.0-20171130231205-49bbdab258c2
+)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/singlemusic/go-prettyjson
 go 1.12
 
 require (
-	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.9.0
-	gitlab.com/c0b/go-ordered-json v0.0.0-20171130231205-49bbdab258c2
+	github.com/singlemusic/go-ordered-json v0.0.0-20200507183230-fbd4eee0efb7
 )

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVc
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.11 h1:FxPOTFNqGkuDUGi3H/qkUbQO4ZiBa2brKq5r0l8TGeM=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
-gitlab.com/c0b/go-ordered-json v0.0.0-20171130231205-49bbdab258c2 h1:M+r1hdmjZc4L4SCn0ZIq/5YQIRxprV+kOf7n7f04l5o=
-gitlab.com/c0b/go-ordered-json v0.0.0-20171130231205-49bbdab258c2/go.mod h1:NREvu3a57BaK0R1+ztrEzHWiZAihohNLQ6trPxlIqZI=
+github.com/singlemusic/go-ordered-json v0.0.0-20200507183230-fbd4eee0efb7 h1:mjNl5xiEIf7m4IixjrLMKaEtIS8bVuVoq07sHPnWzz4=
+github.com/singlemusic/go-ordered-json v0.0.0-20200507183230-fbd4eee0efb7/go.mod h1:iXzLyHtjAAI5exX/Cs1xST9bfPfrZiLT+FDOa6eUzGA=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
+github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
+github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.11 h1:FxPOTFNqGkuDUGi3H/qkUbQO4ZiBa2brKq5r0l8TGeM=
+github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
+gitlab.com/c0b/go-ordered-json v0.0.0-20171130231205-49bbdab258c2 h1:M+r1hdmjZc4L4SCn0ZIq/5YQIRxprV+kOf7n7f04l5o=
+gitlab.com/c0b/go-ordered-json v0.0.0-20171130231205-49bbdab258c2/go.mod h1:NREvu3a57BaK0R1+ztrEzHWiZAihohNLQ6trPxlIqZI=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/prettyjson.go
+++ b/prettyjson.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"gitlab.com/c0b/go-ordered-json"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -62,13 +63,15 @@ func NewFormatter() *Formatter {
 
 // Marshal marshals and formats JSON data.
 func (f *Formatter) Marshal(v interface{}) ([]byte, error) {
-
 	data, err := json.Marshal(v)
 	if err != nil {
 		return nil, err
 	}
-	switch v.(type) {
-	case []interface{}:
+	rt := reflect.TypeOf(v)
+	switch rt.Kind() {
+	case reflect.Slice:
+		return f.FormatArray(data)
+	case reflect.Array:
 		return f.FormatArray(data)
 	default:
 		return f.Format(data)

--- a/prettyjson_test.go
+++ b/prettyjson_test.go
@@ -100,7 +100,7 @@ type TestObject struct {
 func TestMarshal_StructKeyOrder(t *testing.T) {
 	f := NewFormatter()
 	output, err := f.Marshal(&TestObject{
-		Id: "1234",
+		Id:              "1234",
 		AnotherProperty: "Foo",
 	})
 	if err != nil {
@@ -111,6 +111,37 @@ func TestMarshal_StructKeyOrder(t *testing.T) {
   %s: %s,
   %s: %s
 }`
+
+	blueBold := color.New(color.FgBlue, color.Bold).SprintFunc()
+	greenBold := color.New(color.FgGreen, color.Bold).SprintFunc()
+
+	expected := fmt.Sprintf(expectedFormat,
+		blueBold(`"Id"`), greenBold(`"1234"`),
+		blueBold(`"AnotherProperty"`), greenBold(`"Foo"`),
+	)
+	if string(output) != expected {
+		t.Errorf("actual: %s\nexpected: %s", string(output), expected)
+	}
+}
+
+func TestMarshal_StructList(t *testing.T) {
+	f := NewFormatter()
+	objects := make([]TestObject, 0)
+	objects = append(objects, TestObject{
+		Id:              "1234",
+		AnotherProperty: "Foo",
+	})
+	output, err := f.Marshal(&objects)
+	if err != nil {
+		t.Errorf("marshal failed: %s", err)
+	}
+
+	expectedFormat := `[
+  {
+    %s: %s,
+    %s: %s
+  }
+]`
 
 	blueBold := color.New(color.FgBlue, color.Bold).SprintFunc()
 	greenBold := color.New(color.FgGreen, color.Bold).SprintFunc()

--- a/prettyjson_test.go
+++ b/prettyjson_test.go
@@ -9,36 +9,6 @@ import (
 	"github.com/fatih/color"
 )
 
-func Example() {
-	v := map[string]interface{}{
-		"str":   "foo",
-		"num":   100,
-		"bool":  false,
-		"null":  nil,
-		"array": []string{"foo", "bar", "baz"},
-		"map": map[string]interface{}{
-			"foo": "bar",
-		},
-	}
-	s, _ := Marshal(v)
-	fmt.Println(string(s))
-	// Output:
-	// {
-	//   [34;1m"array"[0m: [
-	//     [32;1m"foo"[0m,
-	//     [32;1m"bar"[0m,
-	//     [32;1m"baz"[0m
-	//   ],
-	//   [34;1m"bool"[0m: [33;1mfalse[0m,
-	//   [34;1m"map"[0m: {
-	//     [34;1m"foo"[0m: [32;1m"bar"[0m
-	//   },
-	//   [34;1m"null"[0m: [30;1mnull[0m,
-	//   [34;1m"num"[0m: [36;1m100[0m,
-	//   [34;1m"str"[0m: [32;1m"foo"[0m
-	// }
-}
-
 func TestMarshal(t *testing.T) {
 	prettyJSON := func(s string) string {
 		var v interface{}
@@ -120,6 +90,38 @@ func TestMarshal(t *testing.T) {
 		fmt.Sprintf("{\n  %s: %s\n}", blueBold(`"x"`), cyanBold("123456789123456789123456789")),
 		prettyJSON(`{"x":123456789123456789123456789}`),
 	)
+}
+
+type TestObject struct {
+	Id              string
+	AnotherProperty string
+}
+
+func TestMarshal_StructKeyOrder(t *testing.T) {
+	f := NewFormatter()
+	output, err := f.Marshal(&TestObject{
+		Id: "1234",
+		AnotherProperty: "Foo",
+	})
+	if err != nil {
+		t.Errorf("marshal failed: %s", err)
+	}
+
+	expectedFormat := `{
+  %s: %s,
+  %s: %s
+}`
+
+	blueBold := color.New(color.FgBlue, color.Bold).SprintFunc()
+	greenBold := color.New(color.FgGreen, color.Bold).SprintFunc()
+
+	expected := fmt.Sprintf(expectedFormat,
+		blueBold(`"Id"`), greenBold(`"1234"`),
+		blueBold(`"AnotherProperty"`), greenBold(`"Foo"`),
+	)
+	if string(output) != expected {
+		t.Errorf("actual: %s\nexpected: %s", string(output), expected)
+	}
 }
 
 func TestStringEscape(t *testing.T) {


### PR DESCRIPTION
Say you have a struct like:
```go
type Something struct {
    Id              string
    AnotherProperty string
}
```
`go-prettyjson` would always print this with the keys in alphabetical order:
```json
{
  "AnotherProperty": "Foo",
  "Id": 1234
}
```

What this change does is preserve the struct order of the keys in the output, so it looks like:
```json
{
  "Id": 1234,
  "AnotherProperty": "Foo"
}
```

This more closely matches the behavior of the default json marshaller.