### PR TITLE
Fix printing map keys

### DIFF
--- a/prettyjson.go
+++ b/prettyjson.go
@@ -149,7 +149,12 @@ func (f *Formatter) processMap(m map[string]interface{}, depth int) string {
 
 	for _, key := range keys {
 		val := m[key]
-		k := f.sprintfColor(f.KeyColor, `"%s"`, key)
+		buf := &bytes.Buffer{}
+		encoder := json.NewEncoder(buf)
+		encoder.SetEscapeHTML(false)
+		encoder.Encode(key)
+		s := strings.TrimSuffix(string(buf.Bytes()), "\n")
+		k := f.sprintColor(f.KeyColor, s)
 		v := f.pretty(val, depth+1)
 
 		valueIndent := " "

--- a/prettyjson_test.go
+++ b/prettyjson_test.go
@@ -120,6 +120,11 @@ func TestMarshal(t *testing.T) {
 		fmt.Sprintf("{\n  %s: %s\n}", blueBold(`"x"`), cyanBold("123456789123456789123456789")),
 		prettyJSON(`{"x":123456789123456789123456789}`),
 	)
+
+	test(
+		fmt.Sprintf("{\n  %s: %s\n}", blueBold(`"foo\"bar\n\r\t<>★"`), cyanBold("1")),
+		prettyJSON(`{"foo\"bar\n\r\t<>★":1}`),
+	)
 }
 
 func TestStringEscape(t *testing.T) {


### PR DESCRIPTION
The library prints the map keys incorrectly; for example
```
{"foo\"bar\n\r\t<>":1}
```
is printed like
```
{
  "foo"bar
<>": 1
}
```

Originally reported at: https://github.com/itchyny/gojq/issues/48.