### PR TITLE
Fix example test by setting color.NoColor false

### DIFF
--- a/prettyjson_test.go
+++ b/prettyjson_test.go
@@ -10,6 +10,9 @@ import (
 )
 
 func Example() {
+	defer func(noColor bool) { color.NoColor = noColor }(color.NoColor)
+	color.NoColor = false
+
 	v := map[string]interface{}{
 		"str":   "foo",
 		"num":   100,


### PR DESCRIPTION
I am not sure how you made this work, but `go test ./...` fails due to this test. This is very confusing so I fixed the test.